### PR TITLE
Do not crash in php8+ if page visited before configured.

### DIFF
--- a/ProcessSwitchUser.module
+++ b/ProcessSwitchUser.module
@@ -40,7 +40,7 @@ class ProcessSwitchUser extends Process implements Module, ConfigurableModule {
 
 	public function ___execute() {
 		// Are we allowed to use this module?
-		if (!in_array($this->user->id, $this->who_can_use)) {
+		if (!in_array($this->user->id, $this->who_can_use ?? [])) {
 			$this->error(__('You do not have permission to switch user accounts'));
 			$this->session->redirect($this->pages->get(2)->url);
 		}
@@ -101,7 +101,7 @@ class ProcessSwitchUser extends Process implements Module, ConfigurableModule {
 
 	public function checkPermission($event) {
 		$page = $event->object;
-		if ($page->process == 'ProcessSwitchUser' && !$this->user->matches('id=' . implode('|', $this->who_can_use))) {
+		if ($page->process == 'ProcessSwitchUser' && !$this->user->matches('id=' . implode('|', $this->who_can_use ?? []))) {
 			$event->return = false;
 		}
 	}


### PR DESCRIPTION
If you install this, then immediately visit the Switch User page, ProcessWire crashes because the `who_can_use` property has not yet been initialised to an array, which is required by various of php8's function signatures.

This PR fixes that by coalescing a null value to an empty array, which means the user gets a normal error message instead of a crash.


Thanks for a v useful module!